### PR TITLE
Fix server not getting version from provider

### DIFF
--- a/internal/k3s/server.go
+++ b/internal/k3s/server.go
@@ -211,6 +211,7 @@ func (s *server) Install(client ssh_client.SSHClient) (err error) {
 		flags = append(flags, fmt.Sprintf("K3S_TOKEN=%s", s.token))
 	}
 
+	// Did version get set?
 	if s.version != "" {
 		flags = append(flags, fmt.Sprintf("INSTALL_K3S_VERSION=\"%s\"", s.version))
 	}
@@ -314,7 +315,6 @@ func (s *server) Update(client ssh_client.SSHClient) error {
 }
 
 func (s *server) Resync(client ssh_client.SSHClient) (err error) {
-
 	if s.token == "" {
 		s.token, err = s.getToken(client)
 		if err != nil {

--- a/internal/provider/k3s_agent_resource_test.go
+++ b/internal/provider/k3s_agent_resource_test.go
@@ -21,7 +21,6 @@ func TestAccK3sAgentResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("%v", err.Error())
 	}
-	inputs = inputs.AgentTests()
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -29,8 +28,8 @@ func TestAccK3sAgentResource(t *testing.T) {
 				ConfigFile: K3sAgentStaticFile,
 				Config:     providerConfig,
 				ConfigVariables: map[string]config.Variable{
-					"server_host": config.StringVariable(inputs.Nodes[0]),
-					"agent_hosts": config.ListVariable(config.StringVariable(inputs.Nodes[1])),
+					"server_host": config.StringVariable(inputs.Nodes.Server[0]),
+					"agent_hosts": config.ListVariable(config.StringVariable(inputs.Nodes.Agent[0])),
 					"user":        config.StringVariable(inputs.User),
 					"private_key": config.StringVariable(inputs.SshKey),
 				},
@@ -49,7 +48,7 @@ func TestAccK3sAgentResource(t *testing.T) {
 			{
 				PreConfig: func() {
 
-					client, err := inputs.SshClient(t, 0)
+					client, err := inputs.ServerSshClient(t, 0)
 					if err != nil {
 						t.Errorf("Could not create ssh client: %v", err.Error())
 					}
@@ -75,8 +74,8 @@ func TestAccK3sAgentResource(t *testing.T) {
 				PlanOnly:           true,
 				ConfigFile:         K3sAgentStaticFile,
 				ConfigVariables: map[string]config.Variable{
-					"server_host": config.StringVariable(inputs.Nodes[0]),
-					"agent_hosts": config.ListVariable(config.StringVariable(inputs.Nodes[1]), config.StringVariable(inputs.Nodes[2])),
+					"server_host": config.StringVariable(inputs.Nodes.Server[0]),
+					"agent_hosts": config.ListVariable(config.StringVariable(inputs.Nodes.Agent[1]), config.StringVariable(inputs.Nodes.Agent[2])),
 					"user":        config.StringVariable(inputs.User),
 					"private_key": config.StringVariable(inputs.SshKey),
 				},

--- a/internal/provider/k3s_server_resource.go
+++ b/internal/provider/k3s_server_resource.go
@@ -108,6 +108,7 @@ func (s *K3sServerResource) Configure(ctx context.Context, req resource.Configur
 		resp.Diagnostics.AddError("Provider error", "Could not convert provider data into version")
 		return
 	}
+
 	if provider.Version != "" {
 		s.version = &provider.Version
 	}
@@ -122,6 +123,8 @@ func (s *K3sServerResource) Create(ctx context.Context, req resource.CreateReque
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	data.SetVersion(s.version)
 
 	auth := handlers.NewNodeAuth(ctx, data.Auth)
 	server, err := data.ToServer(ctx)
@@ -176,6 +179,7 @@ func (s *K3sServerResource) Read(ctx context.Context, req resource.ReadRequest, 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+	data.SetVersion(s.version)
 
 	auth := handlers.NewNodeAuth(ctx, data.Auth)
 	server, err := data.ToServer(ctx)
@@ -200,6 +204,9 @@ func (s *K3sServerResource) Update(ctx context.Context, req resource.UpdateReque
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+
+	data.SetVersion(s.version)
+	state.SetVersion(s.version)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/k3s_server_resource_test.go
+++ b/internal/provider/k3s_server_resource_test.go
@@ -20,7 +20,7 @@ func TestAccK3sServerResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("%v", err.Error())
 	}
-	inputs = inputs.ServerTests()
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -28,7 +28,7 @@ func TestAccK3sServerResource(t *testing.T) {
 				ConfigFile: K3sServerStaticFile,
 				Config:     providerConfig,
 				ConfigVariables: map[string]config.Variable{
-					"host":        config.StringVariable(inputs.Nodes[0]),
+					"host":        config.StringVariable(inputs.Nodes.Server[0]),
 					"user":        config.StringVariable(inputs.User),
 					"private_key": config.StringVariable(inputs.SshKey),
 				},
@@ -42,7 +42,7 @@ func TestAccK3sServerResource(t *testing.T) {
 			{
 				PreConfig: func() {
 
-					client, err := inputs.SshClient(t, 0)
+					client, err := inputs.ServerSshClient(t, 0)
 					if err != nil {
 						t.Errorf("Could not create ssh client: %v", err.Error())
 					}
@@ -66,7 +66,7 @@ func TestAccK3sServerResource(t *testing.T) {
 				ConfigFile: K3sServerStaticFile,
 				Config:     providerConfig,
 				ConfigVariables: map[string]config.Variable{
-					"host":        config.StringVariable(inputs.Nodes[0]),
+					"host":        config.StringVariable(inputs.Nodes.Server[0]),
 					"user":        config.StringVariable(inputs.User),
 					"private_key": config.StringVariable(inputs.SshKey),
 					"config":      config.StringVariable("node-label: [\"unit-test=basic\"]"),
@@ -79,7 +79,7 @@ func TestAccK3sServerResource(t *testing.T) {
 				ConfigFile: K3sServerStaticFile,
 				Config:     providerConfig,
 				PreConfig: func() {
-					client, err := inputs.SshClient(t, 0)
+					client, err := inputs.ServerSshClient(t, 0)
 					if err != nil {
 						t.Errorf("Could not create ssh client: %v", err.Error())
 					}
@@ -99,7 +99,7 @@ func TestAccK3sServerResource(t *testing.T) {
 				},
 				PlanOnly: true,
 				ConfigVariables: map[string]config.Variable{
-					"host":        config.StringVariable(inputs.Nodes[0]),
+					"host":        config.StringVariable(inputs.Nodes.Server[0]),
 					"user":        config.StringVariable(inputs.User),
 					"private_key": config.StringVariable(inputs.SshKey),
 					"config":      config.StringVariable("node-label: [\"unit-test=basic\"]"),
@@ -109,7 +109,7 @@ func TestAccK3sServerResource(t *testing.T) {
 				ConfigFile: K3sServerStaticFile,
 				Config:     providerConfig,
 				ConfigVariables: map[string]config.Variable{
-					"host":        config.StringVariable(inputs.Nodes[0]),
+					"host":        config.StringVariable(inputs.Nodes.Server[0]),
 					"user":        config.StringVariable(inputs.User),
 					"private_key": config.StringVariable(inputs.SshKey),
 					"config":      config.StringVariable("node-label: [\"unit-test=basic\"]"),
@@ -127,7 +127,6 @@ func TestAccK3sHAServerResource(t *testing.T) {
 	if err != nil {
 		t.Errorf("%v", err.Error())
 	}
-	inputs = inputs.ServerTests()
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
@@ -136,9 +135,9 @@ func TestAccK3sHAServerResource(t *testing.T) {
 				Config:     providerConfig,
 				ConfigVariables: map[string]config.Variable{
 					"hosts": config.ListVariable(
-						config.StringVariable(inputs.Nodes[1]),
-						config.StringVariable(inputs.Nodes[2]),
-						config.StringVariable(inputs.Nodes[3]),
+						config.StringVariable(inputs.Nodes.Server[1]),
+						config.StringVariable(inputs.Nodes.Server[2]),
+						config.StringVariable(inputs.Nodes.Server[3]),
 					),
 					"user":        config.StringVariable(inputs.User),
 					"private_key": config.StringVariable(inputs.SshKey),
@@ -155,9 +154,9 @@ func TestAccK3sHAServerResource(t *testing.T) {
 				Config:     providerConfig,
 				ConfigVariables: map[string]config.Variable{
 					"hosts": config.ListVariable(
-						config.StringVariable(inputs.Nodes[1]),
-						config.StringVariable(inputs.Nodes[2]),
-						config.StringVariable(inputs.Nodes[3]),
+						config.StringVariable(inputs.Nodes.Server[1]),
+						config.StringVariable(inputs.Nodes.Server[2]),
+						config.StringVariable(inputs.Nodes.Server[3]),
 					),
 					"user":        config.StringVariable(inputs.User),
 					"private_key": config.StringVariable(inputs.SshKey),
@@ -171,7 +170,7 @@ func TestAccK3sHAServerResource(t *testing.T) {
 			{
 				PreConfig: func() {
 
-					client, err := inputs.SshClient(t, 1)
+					client, err := inputs.ServerSshClient(t, 1)
 					if err != nil {
 						t.Errorf("Could not create ssh client: %v", err.Error())
 					}
@@ -197,9 +196,9 @@ func TestAccK3sHAServerResource(t *testing.T) {
 				PlanOnly:   true,
 				ConfigVariables: map[string]config.Variable{
 					"hosts": config.ListVariable(
-						config.StringVariable(inputs.Nodes[1]),
-						config.StringVariable(inputs.Nodes[2]),
-						config.StringVariable(inputs.Nodes[3]),
+						config.StringVariable(inputs.Nodes.Server[1]),
+						config.StringVariable(inputs.Nodes.Server[2]),
+						config.StringVariable(inputs.Nodes.Server[3]),
 					),
 					"user":        config.StringVariable(inputs.User),
 					"private_key": config.StringVariable(inputs.SshKey),
@@ -211,9 +210,9 @@ func TestAccK3sHAServerResource(t *testing.T) {
 				Config:     providerConfig,
 				ConfigVariables: map[string]config.Variable{
 					"hosts": config.ListVariable(
-						config.StringVariable(inputs.Nodes[1]),
-						config.StringVariable(inputs.Nodes[2]),
-						config.StringVariable(inputs.Nodes[3]),
+						config.StringVariable(inputs.Nodes.Server[1]),
+						config.StringVariable(inputs.Nodes.Server[2]),
+						config.StringVariable(inputs.Nodes.Server[3]),
 					),
 					"user":        config.StringVariable(inputs.User),
 					"private_key": config.StringVariable(inputs.SshKey),
@@ -222,6 +221,79 @@ func TestAccK3sHAServerResource(t *testing.T) {
 				Destroy: true,
 			},
 		},
+	})
+}
+
+func TestAccK3sServerSetVersion(t *testing.T) {
+	// Read text to inject provider version
+	raw, _ := os.ReadFile("../../examples/resources/k3s_server/examples/basic/resource.tf")
+
+	inputs, err := LoadInputs(os.Getenv("TEST_JSON_PATH"))
+	if err != nil {
+		t.Errorf("%v", err.Error())
+	}
+	providerConfig := `
+provider "k3s" {
+	k3s_version = "v1.32.7+k3s1"
+}
+	` + string(raw)
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		IsUnitTest:               true,
+		Steps: []resource.TestStep{{
+			Config: providerConfig,
+			ConfigVariables: map[string]config.Variable{
+				"host":        config.StringVariable(inputs.Nodes.Server[4]),
+				"user":        config.StringVariable(inputs.User),
+				"private_key": config.StringVariable(inputs.SshKey),
+			},
+			ConfigStateChecks: []statecheck.StateCheck{
+				statecheck.ExpectSensitiveValue(
+					"k3s_server.main",
+					tfjsonpath.New("token"),
+				),
+			},
+		},
+			{
+				PreConfig: func() {
+
+					client, err := inputs.ServerSshClient(t, 4)
+					if err != nil {
+						t.Errorf("Could not create ssh client: %v", err.Error())
+					}
+
+					jres, err := client.Run("sudo k3s kubectl version -o json")
+					if err != nil {
+						t.Errorf("Could not run kubectl command: %v", err.Error())
+					}
+
+					var kversion map[string]any
+					if err := json.Unmarshal([]byte(jres[0]), &kversion); err != nil {
+						t.Fatal(err.Error())
+					}
+					serverVersion, ok := kversion["serverVersion"].(map[string]interface{})
+					if !ok {
+						t.Fatalf("serverVersion is not a map[string]interface{}")
+					}
+					gitVersion, ok := serverVersion["gitVersion"].(string)
+					if !ok {
+						t.Fatalf("gitVersion is not a string")
+					}
+					if gitVersion != "v1.32.7+k3s1" {
+						t.Errorf("Wrong k3s version, expected 'v1.32.7+k3s1', got '%s'", gitVersion)
+					}
+
+				},
+				Config:   providerConfig,
+				PlanOnly: true,
+				ConfigVariables: map[string]config.Variable{
+					"host":        config.StringVariable(inputs.Nodes.Server[4]),
+					"user":        config.StringVariable(inputs.User),
+					"private_key": config.StringVariable(inputs.SshKey),
+				},
+				ExpectNonEmptyPlan: false,
+			}},
 	})
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -69,8 +69,8 @@ func (p *K3sProvider) Schema(_ context.Context, _ provider.SchemaRequest, resp *
 // Configure prepares a HashiCups API client for data sources and resources.
 func (p *K3sProvider) Configure(ctx context.Context, req provider.ConfigureRequest, resp *provider.ConfigureResponse) {
 	var config k3sProviderModel
-	diags := req.Config.Get(ctx, &config)
-	resp.Diagnostics.Append(diags...)
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
 
 	if resp.Diagnostics.HasError() {
 		return
@@ -99,14 +99,12 @@ func (p *K3sProvider) Configure(ctx context.Context, req provider.ConfigureReque
 		version = config.Version.ValueString()
 	}
 
-	p.Version = version
-
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.ResourceData = p
-	resp.DataSourceData = p
+	resp.ResourceData = &K3sProvider{Version: version}
+	resp.DataSourceData = &K3sProvider{Version: version}
 }
 
 // DataSources defines the data sources implemented in the provider.

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -31,29 +31,21 @@ var testAccProtoV6ProviderFactories = map[string]func() (tfprotov6.ProviderServe
 }
 
 type StandupInputs struct {
-	Nodes  []string `json:"nodes"`
-	SshKey string   `json:"ssh_key"`
-	User   string   `json:"user"`
-}
-
-func (s StandupInputs) AgentTests() StandupInputs {
-	return StandupInputs{
-		s.Nodes[0:3],
-		s.SshKey,
-		s.User,
-	}
-}
-
-func (s StandupInputs) ServerTests() StandupInputs {
-	return StandupInputs{
-		s.Nodes[3:len(s.Nodes)],
-		s.SshKey,
-		s.User,
-	}
+	Nodes struct {
+		Agent  []string `json:"agent"`
+		Server []string `json:"server"`
+	} `json:"nodes"`
+	SshKey string `json:"ssh_key"`
+	User   string `json:"user"`
 }
 
 func LoadInputs(f string) (StandupInputs, error) {
 	var output StandupInputs
+
+	if f == "" {
+		f = "../../_vars.test.auto.tfvars.json"
+	}
+
 	file, err := os.Open(f)
 	if err != nil {
 		return output, err
@@ -68,8 +60,12 @@ func LoadInputs(f string) (StandupInputs, error) {
 	return output, err
 }
 
-func (s *StandupInputs) SshClient(t *testing.T, index uint) (ssh_client.SSHClient, error) {
-	return ssh_client.NewSSHClient(t.Context(), s.Nodes[index], 22, s.User, s.SshKey, "")
+func (s *StandupInputs) AgentSshClient(t *testing.T, index uint) (ssh_client.SSHClient, error) {
+	return ssh_client.NewSSHClient(t.Context(), s.Nodes.Agent[index], 22, s.User, s.SshKey, "")
+}
+
+func (s *StandupInputs) ServerSshClient(t *testing.T, index uint) (ssh_client.SSHClient, error) {
+	return ssh_client.NewSSHClient(t.Context(), s.Nodes.Server[index], 22, s.User, s.SshKey, "")
 }
 
 func Render(raw string, args map[string]string) (string, error) {

--- a/tests/infra/modules/openstack-backend/main.tf
+++ b/tests/infra/modules/openstack-backend/main.tf
@@ -21,14 +21,10 @@ module "labels" {
 
 // Resources
 
-resource "tls_private_key" "ssh_keys" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
-}
 
 resource "openstack_compute_keypair_v2" "keypair" {
   name       = "${module.labels.id}-keypair"
-  public_key = tls_private_key.ssh_keys.public_key_openssh
+  public_key = var.ssh_keys.public_key_openssh
 }
 
 data "openstack_networking_network_v2" "float_ip_network" {

--- a/tests/infra/modules/openstack-backend/outputs.tf
+++ b/tests/infra/modules/openstack-backend/outputs.tf
@@ -1,7 +1,4 @@
-output "ssh_key" {
-  value     = tls_private_key.ssh_keys.private_key_openssh
-  sensitive = true
-}
+
 output "nodes" {
   value = openstack_compute_instance_v2.k8s_node[*].access_ip_v4
 }

--- a/tests/infra/modules/openstack-backend/variables.tf
+++ b/tests/infra/modules/openstack-backend/variables.tf
@@ -29,3 +29,7 @@ variable "nodes" {
   type    = number
   default = 4
 }
+
+variable "ssh_keys" {
+  type = any
+}


### PR DESCRIPTION
## Related Issue

Fixes # https://github.com/Striveworks/terraform-provider-k3s/issues/58

## Description

The server wasn't getting the k3s version set by the provider during install. The agent was, which could cause api clashes.

 