### PR TITLE
Exposing full k3s_url on data kubeconfig

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,8 @@ repos:
       - id: trailing-whitespace
         exclude: docs/
       - id: check-merge-conflict
-  - repo: local
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v2.8.0 # Use the latest version
     hooks:
       - id: golangci-lint
-        name: GolangCI-Lint
-        entry: golangci-lint run -c .golangci.yml --fix
-        pass_filenames: false # needs to run on entire dir
-        language: system
-        types: [go]
-        files: \.go$
-        verbose: true
+        args: [--fix]

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ install: build ## Install locally the plugin
 
 .PHONY: lint
 lint: ## Lints the entire repo
-	golangci-lint run
+	docker run -t --rm -v $$(pwd):/app -w /app golangci/golangci-lint:v2.8.0 golangci-lint run
 
 .PHONY: generate
 generate: ## Generates plugin docs. WARNING Only target requiring terraform and not opentofu

--- a/docs/data-sources/kubeconfig.md
+++ b/docs/data-sources/kubeconfig.md
@@ -71,6 +71,7 @@ output "kubeconfig" {
 ### Read-Only
 
 - `cluster_auth` (Attributes) Cluster auth objects (see [below for nested schema](#nestedatt--cluster_auth))
+- `k3s_url` (String) K3S_URL variable
 - `kubeconfig` (String, Sensitive) Output of the kubeconfig from a k3s_server resource
 
 <a id="nestedatt--auth"></a>

--- a/internal/handlers/kubeconfig.go
+++ b/internal/handlers/kubeconfig.go
@@ -14,6 +14,7 @@ type K3sKubeConfig struct {
 	ClusterAuth types.Object `tfsdk:"cluster_auth"`
 	KubeConfig  types.String `tfsdk:"kubeconfig"`
 	Hostname    types.String `tfsdk:"hostname"`
+	K3sUrl      types.String `tfsdk:"k3s_url"`
 	AllowEmpty  types.Bool   `tfsdk:"allow_empty"`
 }
 
@@ -63,6 +64,7 @@ func (s *K3sKubeConfig) Read(ctx context.Context, auth TKubeConfigRead, server T
 		clusterAuth.UpdateHost(s.Hostname.ValueString())
 	}
 
+	s.K3sUrl = clusterAuth.Server
 	s.Auth = auth.ToObject(ctx)
 	s.ClusterAuth = clusterAuth.ToObject(ctx)
 	s.KubeConfig = types.StringValue(clusterAuth.KubeConfig())

--- a/internal/provider/k3s_kubeconfig_data.go
+++ b/internal/provider/k3s_kubeconfig_data.go
@@ -60,6 +60,10 @@ func (k *K3sKubeConfigData) Schema(_ context.Context, req datasource.SchemaReque
 				Optional:            true,
 				MarkdownDescription: "Override the api server's hostname",
 			},
+			"k3s_url": schema.StringAttribute{
+				Computed:            true,
+				MarkdownDescription: "K3S_URL variable",
+			},
 		},
 	}
 }


### PR DESCRIPTION
Removes confusion about using the kubeconfig data object's url to pass to agents (especially in HA mode with a load balancer in from of all controllers)
