### PR TITLE
Adding sensitive env var option

### DIFF
--- a/docs/resources/agent.md
+++ b/docs/resources/agent.md
@@ -74,6 +74,7 @@ resource "k3s_agent" "main" {
 - `allow_delete_err` (Boolean) If this is true, deleting the node using kubectl first will be allowed to error not stopping the k3s uninstall process
 - `bin_dir` (String) Value of a path used to put the k3s binary
 - `config` (String) K3s server config
+- `env` (Map of String, Sensitive) Extra environment variables to pass to the process
 - `registry` (String) K3s agent registry
 
 ### Read-Only

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -178,6 +178,7 @@ output "jwks" {
 
 - `bin_dir` (String) Value of a path used to put the k3s binary
 - `config` (String) K3s server config
+- `env` (Map of String, Sensitive) Extra environment variables to pass to the process
 - `highly_available` (Attributes) Run server node in highly available mode (see [below for nested schema](#nestedatt--highly_available))
 - `oidc` (Attributes) Support for including oidc provider in k3s (see [below for nested schema](#nestedatt--oidc))
 - `registry` (String) K3s server registry

--- a/internal/k3s/server_test.go
+++ b/internal/k3s/server_test.go
@@ -19,6 +19,7 @@ write-kubeconfig-mode: "0700"`,
     "endpoint": ["1234"]`,
 		"",
 		"",
+		make(map[string]string),
 	)
 	if err != nil {
 		t.Fatalf("Expected nil err but found: %v", err.Error())

--- a/internal/provider/k3s_server_resource.go
+++ b/internal/provider/k3s_server_resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"striveworks.us/terraform-provider-k3s/internal/handlers"
 )
@@ -46,6 +47,12 @@ func (s *K3sServerResource) Schema(context context.Context, resource resource.Sc
 			"config": schema.StringAttribute{
 				Optional:            true,
 				MarkdownDescription: "K3s server config",
+			},
+			"env": schema.MapAttribute{
+				Optional:            true,
+				Sensitive:           true,
+				MarkdownDescription: "Extra environment variables to pass to the process",
+				ElementType:         types.StringType,
 			},
 			"registry": schema.StringAttribute{
 				Optional:            true,
@@ -127,9 +134,9 @@ func (s *K3sServerResource) Create(ctx context.Context, req resource.CreateReque
 	data.SetVersion(s.version)
 
 	auth := handlers.NewNodeAuth(ctx, data.Auth)
-	server, err := data.ToServer(ctx)
-	if err != nil {
-		resp.Diagnostics.AddError("creating k3s server", err.Error())
+	server, diags := data.ToServer(ctx)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -153,9 +160,9 @@ func (s *K3sServerResource) Delete(ctx context.Context, req resource.DeleteReque
 	}
 
 	auth := handlers.NewNodeAuth(ctx, data.Auth)
-	server, err := data.ToServer(ctx)
-	if err != nil {
-		resp.Diagnostics.AddError("creating k3s server", err.Error())
+	server, diags := data.ToServer(ctx)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -182,9 +189,9 @@ func (s *K3sServerResource) Read(ctx context.Context, req resource.ReadRequest, 
 	data.SetVersion(s.version)
 
 	auth := handlers.NewNodeAuth(ctx, data.Auth)
-	server, err := data.ToServer(ctx)
-	if err != nil {
-		resp.Diagnostics.AddError("creating k3s server", err.Error())
+	server, diags := data.ToServer(ctx)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 
@@ -213,9 +220,9 @@ func (s *K3sServerResource) Update(ctx context.Context, req resource.UpdateReque
 	}
 
 	auth := handlers.NewNodeAuth(ctx, data.Auth)
-	server, err := data.ToServer(ctx)
-	if err != nil {
-		resp.Diagnostics.AddError("creating k3s server", err.Error())
+	server, diags := data.ToServer(ctx)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
 		return
 	}
 

--- a/internal/ssh_client/client.go
+++ b/internal/ssh_client/client.go
@@ -219,7 +219,8 @@ func (s *sshClient) streamSingle(command string) error {
 
 	// Wait for the command to finish
 	if err := session.Wait(); err != nil {
-		return fmt.Errorf("cannot run cmd '%s': %s", command, err)
+		tflog.Error(s.ctx, fmt.Sprintf("cannot run cmd '%s': %s", command, err))
+		return fmt.Errorf("cannot run cmd, see error logs") // Mask error command to prevent secret leakage
 	}
 
 	return nil


### PR DESCRIPTION
Adds a `map(string)` to the agent and server to allow env vars `K3S_` to the install command